### PR TITLE
Improve API resilience with updated retry logic and intervals

### DIFF
--- a/apps/web/src/hooks/useDlqHistory.ts
+++ b/apps/web/src/hooks/useDlqHistory.ts
@@ -14,11 +14,13 @@ export function useDlqHistory(params: DlqHistoryParams, enabled = true) {
     queryFn: () => dlqHistoryApi.getHistory(params),
     enabled,
     staleTime: 5_000,
-    refetchInterval: 10_000,
+    refetchInterval: 30_000,
     refetchIntervalInBackground: false,
     retry: (failureCount, error: unknown) => {
       const err = error as { response?: { status?: number } };
       if (err?.response?.status === 404) return false;
+      if (err?.response?.status === 429) return false;
+      if ((err?.response?.status ?? 0) >= 500) return false;
       return failureCount < 2;
     },
   });
@@ -57,11 +59,13 @@ export function useDlqSummary(namespaceId?: string) {
     queryFn: () => dlqHistoryApi.getSummary(namespaceId),
     enabled: !!namespaceId,
     staleTime: 5_000,
-    refetchInterval: 10_000,
+    refetchInterval: 30_000,
     refetchIntervalInBackground: false,
     retry: (failureCount, error: unknown) => {
       const err = error as { response?: { status?: number } };
       if (err?.response?.status === 404) return false;
+      if (err?.response?.status === 429) return false;
+      if ((err?.response?.status ?? 0) >= 500) return false;
       return failureCount < 2;
     },
   });

--- a/apps/web/src/hooks/useMessages.ts
+++ b/apps/web/src/hooks/useMessages.ts
@@ -27,7 +27,7 @@ export function useMessages(params: GetMessagesParams & { autoRefresh?: boolean 
         // instead of throwing. This prevents toast spam from background polling
         // when the Service Bus namespace is unavailable.
         const status = (error as ApiError)?.response?.status;
-        if (status === 404 || status === 502 || status === 503) {
+        if (status === 404 || status === 429 || status === 502 || status === 503) {
           return { items: [], totalCount: 0, hasMore: false };
         }
         throw error;
@@ -42,6 +42,8 @@ export function useMessages(params: GetMessagesParams & { autoRefresh?: boolean 
       if (error?.response?.status === 404) return false;
       // Don't retry on 401/403 (auth errors)
       if (error?.response?.status === 401 || error?.response?.status === 403) return false;
+      // Don't retry on 429 — retrying would worsen the rate limit situation
+      if (error?.response?.status === 429) return false;
       // Don't retry on Service Bus connectivity errors
       if ((error?.response?.status ?? 0) >= 500) return false;
       return failureCount < 2;
@@ -96,7 +98,7 @@ export function useSendMessage() {
     onError: (error: ApiError) => {
       const errorMsg = error?.response?.data?.message || error?.message || 'Failed to send message';
       toast.error(errorMsg, {
-        duration: Infinity, // Force user to acknowledge critical failure
+        duration: 8000,
       });
     },
   });
@@ -143,7 +145,7 @@ export function useReplayMessage() {
       } else {
         const errorMsg = error?.response?.data?.message || error?.message || 'Failed to replay message';
         toast.error(errorMsg, {
-          duration: Infinity, // Force user to acknowledge critical failure
+          duration: 8000,
         });
       }
     },

--- a/apps/web/src/hooks/useQueues.ts
+++ b/apps/web/src/hooks/useQueues.ts
@@ -16,6 +16,7 @@ const queuesQueryOptions = (namespaceId: string, autoRefresh: boolean) => ({
   refetchIntervalInBackground: false,
   retry: (failureCount: number, error: ApiError) => {
     if (error?.response?.status === 404) return false;
+    if (error?.response?.status === 429) return false;
     if ((error?.response?.status ?? 0) >= 500) return false;
     return failureCount < 2;
   },
@@ -65,11 +66,12 @@ export function useAllNamespacesQueues(
         return response.data;
       },
       enabled: !!id,
-      staleTime: 2000,
-      refetchInterval: autoRefresh ? 7000 : (false as const),
+      staleTime: 15_000,
+      refetchInterval: autoRefresh ? 30_000 : (false as const),
       refetchIntervalInBackground: false,
       retry: (failureCount: number, error: ApiError) => {
         if (error?.response?.status === 404) return false;
+        if (error?.response?.status === 429) return false;
         if ((error?.response?.status ?? 0) >= 500) return false;
         return failureCount < 2;
       },

--- a/apps/web/src/hooks/useRules.ts
+++ b/apps/web/src/hooks/useRules.ts
@@ -4,6 +4,7 @@ import {
   type CreateRuleRequest,
   type TestRuleRequest,
 } from '@/lib/api/rules';
+import { type ApiError } from '@/lib/api/types';
 import toast from 'react-hot-toast';
 
 const RULES_KEY = ['rules'] as const;
@@ -17,9 +18,15 @@ export function useRules(enabledOnly?: boolean) {
   return useQuery({
     queryKey: [...RULES_KEY, { enabledOnly }],
     queryFn: () => rulesApi.getAll(enabledOnly),
-    staleTime: 10_000,
-    refetchInterval: 10_000, // Match DLQ polling interval for real-time stats
-    refetchIntervalInBackground: false, // Pause when tab inactive
+    staleTime: 30_000,
+    refetchInterval: 30_000, // Reduced from 10s to avoid rate limit pressure
+    refetchIntervalInBackground: false,
+    retry: (failureCount, error: ApiError) => {
+      if (error?.response?.status === 429) return false;
+      if (error?.response?.status === 404) return false;
+      if ((error?.response?.status ?? 0) >= 500) return false;
+      return failureCount < 2;
+    },
   });
 }
 

--- a/apps/web/src/hooks/useSubscriptions.ts
+++ b/apps/web/src/hooks/useSubscriptions.ts
@@ -27,6 +27,7 @@ export function useSubscriptions(namespaceId: string, topicName: string, autoRef
     retry: (failureCount, error: ApiError) => {
       // Don't retry on 404 or Service Bus connectivity errors
       if (error?.response?.status === 404) return false;
+      if (error?.response?.status === 429) return false;
       if ((error?.response?.status ?? 0) >= 500) return false;
       return failureCount < 2;
     },

--- a/apps/web/src/hooks/useTopics.ts
+++ b/apps/web/src/hooks/useTopics.ts
@@ -18,6 +18,7 @@ export function useTopics(namespaceId: string, autoRefresh: boolean = true) {
     retry: (failureCount, error: ApiError) => {
       // Don't retry on 404 or Service Bus connectivity errors
       if (error?.response?.status === 404) return false;
+      if (error?.response?.status === 429) return false;
       if ((error?.response?.status ?? 0) >= 500) return false;
       return failureCount < 2;
     },

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -219,6 +219,17 @@ apiClient.interceptors.response.use(
         }
         break;
       }
+      case 429: {
+        // Rate limit hit — show a single debounced toast, never for silent calls (already exited above)
+        const retryAfter = (error.response.headers as Record<string, string>)?.['retry-after'] ?? '60';
+        const errorKey = '429-rate-limit';
+        if (shouldShowError(errorKey)) {
+          toast.error(`Too many requests. Retry in ${retryAfter}s — try refreshing less frequently.`, {
+            duration: 5000,
+          });
+        }
+        break;
+      }
       case 404: {
         if (!isSilent404(url)) {
           // Show feedback for message operation 404s (replay, dead-letter, cancel)

--- a/services/api/src/ServiceHub.Api/appsettings.Development.json
+++ b/services/api/src/ServiceHub.Api/appsettings.Development.json
@@ -76,5 +76,10 @@
 
   "Swagger": {
     "Enabled": true
+  },
+
+  "RateLimit": {
+    "MaxRequests": 500,
+    "WindowDuration": "00:01:00"
   }
 }

--- a/services/api/src/ServiceHub.Api/appsettings.json
+++ b/services/api/src/ServiceHub.Api/appsettings.json
@@ -82,8 +82,8 @@
   },
   
   "RateLimit": {
-    "PermitLimit": 100,
-    "Window": "00:01:00"
+    "MaxRequests": 100,
+    "WindowDuration": "00:01:00"
   },
   
   "HealthChecks": {


### PR DESCRIPTION
This pull request introduces several improvements to how the frontend handles API rate limits and polling intervals. The changes aim to reduce the risk of hitting rate limits by increasing polling intervals, standardizing error handling for HTTP 429 (Too Many Requests), and making toast notifications less intrusive. Additionally, rate limit configuration keys are updated for consistency on the backend.

**Frontend polling and error handling improvements:**

* Increased polling intervals (`refetchInterval` and `staleTime`) across hooks like `useDlqHistory`, `useDlqSummary`, `useAllNamespacesQueues`, and `useRules` to 30 seconds, reducing the frequency of API calls and the likelihood of hitting rate limits. [[1]](diffhunk://#diff-9f597dce11e4595c457b37c22615cba513b39e3e03014bb47066d9b8ef4719fbL17-R23) [[2]](diffhunk://#diff-9f597dce11e4595c457b37c22615cba513b39e3e03014bb47066d9b8ef4719fbL60-R68) [[3]](diffhunk://#diff-09f7253d8969c1a7e08927124dd87961066c2876cf66ae574ec6ebb34381bdecL68-R74) [[4]](diffhunk://#diff-c7622cb1505f7aa4e4507d280b284f51fb956796b623d86f0ed590ffac4255ddL20-R29)
* Updated retry logic in hooks (`useDlqHistory`, `useDlqSummary`, `useMessages`, `useQueues`, `useRules`, `useSubscriptions`, `useTopics`) to avoid retrying requests on HTTP 429 (rate limit), 404, and 5xx errors, helping to prevent exacerbating rate limit issues. [[1]](diffhunk://#diff-9f597dce11e4595c457b37c22615cba513b39e3e03014bb47066d9b8ef4719fbL17-R23) [[2]](diffhunk://#diff-9f597dce11e4595c457b37c22615cba513b39e3e03014bb47066d9b8ef4719fbL60-R68) [[3]](diffhunk://#diff-1a04f65c2cfb0b50e1068dfb13e050601404efba3bb59b5f65a4a7289f4f7351R45-R46) [[4]](diffhunk://#diff-09f7253d8969c1a7e08927124dd87961066c2876cf66ae574ec6ebb34381bdecR19) [[5]](diffhunk://#diff-09f7253d8969c1a7e08927124dd87961066c2876cf66ae574ec6ebb34381bdecL68-R74) [[6]](diffhunk://#diff-c7622cb1505f7aa4e4507d280b284f51fb956796b623d86f0ed590ffac4255ddL20-R29) [[7]](diffhunk://#diff-705c519a0ff0ab172664117e81b2b0cabcf1dce0cbcfa7ab1aca3f1ebd4988f6R30) [[8]](diffhunk://#diff-d29b3ff98aa285e32c562e90134df28d74ef1089367a6b8e8587c2fb3fed2d71R21)
* In `useMessages`, added HTTP 429 to the list of non-error statuses that return empty results, preventing unnecessary error toasts during rate limiting.

**User experience enhancements:**

* Changed toast error durations for message sending and replay failures from infinite to 8 seconds, making error notifications less disruptive. [[1]](diffhunk://#diff-1a04f65c2cfb0b50e1068dfb13e050601404efba3bb59b5f65a4a7289f4f7351L99-R101) [[2]](diffhunk://#diff-1a04f65c2cfb0b50e1068dfb13e050601404efba3bb59b5f65a4a7289f4f7351L146-R148)
* Added a debounced toast notification for HTTP 429 errors in the API client, informing users about rate limiting and suggesting less frequent refreshing.

**Backend configuration updates:**

* Updated rate limit configuration keys in `appsettings.json` and `appsettings.Development.json` from `PermitLimit`/`Window` to `MaxRequests`/`WindowDuration` for clarity and consistency. [[1]](diffhunk://#diff-07371dcf391c50c51377c1d3b8b87aa6b3c6b07ab1ae1182b7eff292f9556c83L85-R86) [[2]](diffhunk://#diff-074e8bf235124473e6076d9f9db9654bb9d6627a0f1e4c2dbae9cd2eb6120463R79-R83)