### PR TITLE
fix: enhance network error handling with specific timeout messages an…

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -165,12 +165,19 @@ apiClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    // Network error
+    // Network error (includes timeout, connection refused, etc.)
     if (!error.response) {
-      const errorKey = 'network-error';
+      const errorKey = error.code === 'ECONNABORTED' || error.message?.includes('timeout')
+        ? 'timeout-error'
+        : 'network-error';
+      
       if (shouldShowError(errorKey)) {
-        toast.error('Cannot reach the API. If running on a remote server, ensure port 5153 is accessible.', {
-          duration: 5000,
+        const message = errorKey === 'timeout-error'
+          ? 'Request timed out (30s). The API server may be busy or unresponsive. Try again in a moment.'
+          : 'Cannot reach the API. If running on a remote server, ensure port 5153 is accessible.';
+        
+        toast.error(message, {
+          duration: 6000,
         });
       }
       return Promise.reject(error);


### PR DESCRIPTION
This pull request updates the error handling logic for network errors in the `apiClient` response interceptor to provide more specific feedback to users. Now, timeout errors are distinguished from other network errors, and the user receives a clearer, more actionable message.

Error handling improvements:

* Enhanced detection of timeout errors by checking for error code `'ECONNABORTED'` or messages containing `'timeout'`, and introduced a separate `'timeout-error'` key.
* Updated the user-facing error messages: timeout errors now display a specific message about the request timing out and suggest retrying, while other network errors retain the original guidance. The toast notification duration was also increased to 6000ms for better visibility.…d improved toast notifications